### PR TITLE
Added a safety script to set all parameters from the param_set_send commands

### DIFF
--- a/Plane/Operations/safety-script.py
+++ b/Plane/Operations/safety-script.py
@@ -1,0 +1,67 @@
+from pymavlink import mavutil
+import sys
+import os
+
+script_dir = os.path.abspath('./../..')
+sys.path.append(script_dir)
+
+import General.Operations.initialize as initialize
+
+vehicle_connection, valid_connection= initialize.connect_to_vehicle('udpin:127.0.0.1:14550')
+
+def confirm_param():
+    message = vehicle_connection.recv_match(type='PARAM_VALUE', blocking=True).to_dict()
+    print('Set parameter %s to value: %d\n' %
+        (message['param_id'], message['param_value']))
+
+print("Setting maximum airspeed... (Desired value: 15)")
+max_speed = 55 / 3.6 # 55 km/h converted to m/s
+vehicle_connection.mav.param_set_send(
+        vehicle_connection.target_system,
+        vehicle_connection.target_component,
+        b'AIRSPEED_MAX',
+        max_speed,
+        mavutil.mavlink.MAV_PARAM_TYPE_UINT32
+    )
+confirm_param()
+
+print("Setting minimum airspeed... (Desired value: 11)")
+min_speed = 40 / 3.6 # 40 km/h converted to m/s
+vehicle_connection.mav.param_set_send(
+        vehicle_connection.target_system,
+        vehicle_connection.target_component,
+        b'AIRSPEED_MIN',
+        min_speed,
+        mavutil.mavlink.MAV_PARAM_TYPE_UINT32
+    )
+confirm_param()
+
+print("Setting waypoint radius... (Desired value: 0)")
+vehicle_connection.mav.param_set_send(
+        vehicle_connection.target_system,
+        vehicle_connection.target_component,
+        b'WP_RADIUS',
+        0,
+        mavutil.mavlink.MAV_PARAM_TYPE_UINT32
+    )
+confirm_param()
+
+print("Setting waypoint loiter radius... (Desired value: 50)")
+vehicle_connection.mav.param_set_send(
+        vehicle_connection.target_system,
+        vehicle_connection.target_component,
+        b'WP_LOITER_RAD',
+        50,
+        mavutil.mavlink.MAV_PARAM_TYPE_UINT32
+    )
+confirm_param()
+
+print("Setting RTL radius... (Desired value: 50)")
+vehicle_connection.mav.param_set_send(
+        vehicle_connection.target_system,
+        vehicle_connection.target_component,
+        b'RTL_RADIUS',
+        50,
+        mavutil.mavlink.MAV_PARAM_TYPE_UINT32
+    )
+confirm_param()


### PR DESCRIPTION
This script runs through all of our current param_set_send functions and sets the desired values, and sends a confirmation of the parameter value that was set in order to check that the value was properly set.